### PR TITLE
Add Govhack & Github links to front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,8 @@
                                         <div class="medium-5 small-12 columns feature-panel feature-content">
                                             <h2>About?</h2>
                                             <p>GapCycle’s aim is to help people chose a straight forward and safe cycling route between official cycle trails. </p>
+                                            <p>This is a project for <a href="http://govhack.org.nz"></a>GovHack NZ 2016</a>.</p>
+                                            <p>See our <a href="https://2016.hackerspace.govhack.org/content/gapcycle">GovHack Project Page</a> for more information, or use the <a href="https://github.com/GapCycle/gapcycle/issues">Github Issue Queue</a> to make suggestions!</p>
                                         </div>
                                     </article>
                                 </section>


### PR DESCRIPTION
This adds links to the GovHack website, Govhack project page, and Github issue queue.
